### PR TITLE
For Android: fixed position of Menu and vertically centered labels

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -142,7 +142,7 @@ class Menu extends React.Component {
     };
 
     return (
-      <View ref={this._setContainerRef}>
+      <View ref={this._setContainerRef} collapsable={false}>
         <View onLayout={this._onButtonLayout}>{this.props.button}</View>
 
         <Modal visible={this.state.modalOpen} transparent>

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -42,6 +42,7 @@ MenuItem.defaultProps = {
 const styles = StyleSheet.create({
   container: {
     height: 48,
+    justifyContent: 'center',
     maxWidth: 248,
     minWidth: 124,
   },
@@ -49,7 +50,6 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 14,
     fontWeight: '400',
-    lineHeight: 48,
     paddingHorizontal: 16,
   },
 });


### PR DESCRIPTION
This fixes two UI issues on Android:
1) The menu was opening in the top left corner of the screen, regardless of where the menu button was placed. This was caused by the view being collapsed: https://facebook.github.io/react-native/docs/view.html#collapsable. Setting collapsable to false fixed the issue. 
2) The MenuItem titles were at the bottom of their containers, not vertically centered. This was caused by the lineHeight CSS property which behaves differently on iOS vs Android. (See issue here: https://github.com/facebook/react-native/issues/10712). I removed this property and set justifyContent on the container instead.

React native versions:
react-native-cli: 2.0.1
react-native: 0.49.1

Before:
![screenshot_1509557325](https://user-images.githubusercontent.com/805936/32288436-2a8b2838-bef1-11e7-8aba-5f410ba3390f.png)

After:
![screenshot_1509557376](https://user-images.githubusercontent.com/805936/32288451-396d3120-bef1-11e7-8bfb-2b4bdc9d6961.png)