### PR TITLE
Elevation for ios & android default 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ class App extends React.PureComponent {
 
 ### Properties
 
-| name     | description                            |  type | default |
-| :------- | :------------------------------------- | ----: | :------ |
-| children | Components rendered in menu (required) |  Node | -       |
-| button   | Button component (required)            |  Node | -       |
-| style    | Menu style                             | Style | -       |
+| name      | description                            |  type | default |
+| :-------- | :------------------------------------- | ------: | :------ |
+| children  | Components rendered in menu (required) |  Node   | -       |
+| button    | Button component (required)            |  Node   | -       |
+| elevation | Material elevation of the container    |  Number | 8       |
+| style     | Menu style                             | Style   | -       |
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ class App extends React.PureComponent {
 
 ### Properties
 
-| name      | description                            |  type | default |
-| :-------- | :------------------------------------- | ------: | :------ |
-| children  | Components rendered in menu (required) |  Node   | -       |
-| button    | Button component (required)            |  Node   | -       |
-| elevation | Material elevation of the container    |  Number | 8       |
-| style     | Menu style                             | Style   | -       |
+| name     | description                            |  type | default |
+| :------- | :------------------------------------- | ----: | :------ |
+| children | Components rendered in menu (required) |  Node | -       |
+| button   | Button component (required)            |  Node | -       |
+| style    | Menu style                             | Style | -       |
 
 ### Methods
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -28,7 +28,6 @@ class Menu extends React.Component {
   static propTypes = {
     button: PropTypes.node.isRequired,
     children: PropTypes.node.isRequired,
-    elevation: PropTypes.number,
     style: ViewPropTypes.style,
   };
 
@@ -144,24 +143,11 @@ class Menu extends React.Component {
       top += this.state.buttonHeight - MENU_PADDING_VERTICAL * 2;
     }
 
-    // Shadow
-    const { elevation } = this.props
     const shadowMenuContainerStyle = {
       opacity: this.state.opacityAnimation,
       transform: transforms,
       left,
       top,
-      ...Platform.select({
-         ios: {
-           shadowColor: 'black',
-          shadowOffset: { width: 0, height: elevation ? elevation * 0.6 : 4.8 },
-           shadowOpacity: elevation ? 0.0015 * elevation + 0.18 : 0.192,
-           shadowRadius: elevation ? 0.54 * elevation : 4.32,
-         },
-         android: {
-           elevation: elevation ? elevation : 8,
-         },
-       }),
     };
 
     const { menuState } = this.state;
@@ -205,6 +191,22 @@ const styles = StyleSheet.create({
     opacity: 0,
     paddingVertical: MENU_PADDING_VERTICAL,
   },
+
+  /* Shadow container
+   * Default elevation: 8 on android and its equivalent for ios.
+   * Ios shadow formula: https://github.com/alekhurst/react-native-elevated-view/blob/master/index.js
+   */
+  ...Platform.select({
+    ios: {
+      shadowColor: 'black',
+      shadowOffset: { width: 0, height: 4.8 },
+      shadowOpacity: 0.192,
+      shadowRadius: 4.32,
+    },
+    android: {
+      elevation: 8,
+    },
+  }),
 
   menuContainer: {
     overflow: 'hidden',

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -28,6 +28,7 @@ class Menu extends React.Component {
   static propTypes = {
     button: PropTypes.node.isRequired,
     children: PropTypes.node.isRequired,
+    elevation: PropTypes.number,
     style: ViewPropTypes.style,
   };
 
@@ -143,11 +144,24 @@ class Menu extends React.Component {
       top += this.state.buttonHeight - MENU_PADDING_VERTICAL * 2;
     }
 
+    // Shadow
+    const { elevation } = this.props
     const shadowMenuContainerStyle = {
       opacity: this.state.opacityAnimation,
       transform: transforms,
       left,
       top,
+      ...Platform.select({
+         ios: {
+           shadowColor: 'black',
+          shadowOffset: { width: 0, height: elevation ? elevation * 0.6 : 4.8 },
+           shadowOpacity: elevation ? 0.0015 * elevation + 0.18 : 0.192,
+           shadowRadius: elevation ? 0.54 * elevation : 4.32,
+         },
+         android: {
+           elevation: elevation ? elevation : 8,
+         },
+       }),
     };
 
     const { menuState } = this.state;

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -204,19 +204,6 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     opacity: 0,
     paddingVertical: MENU_PADDING_VERTICAL,
-
-    // Shadow
-    ...Platform.select({
-      ios: {
-        shadowColor: 'black',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.14,
-        shadowRadius: 2,
-      },
-      android: {
-        elevation: 2,
-      },
-    }),
   },
 
   menuContainer: {


### PR DESCRIPTION
#10 

# Elevation by props

The default elevation value is 8, and its equivalent for ios ([according to the material design guide from Google for menus](https://material.io/guidelines/material-design/elevation-shadows.html#elevation-shadows-elevation-android)).

## Updated
index.js & readme.md

## Todo
tests on ios