### PR TITLE
Added onHidden callback for when 'menu.hide()' has finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ class App extends React.PureComponent {
 | children | Components rendered in menu (required) |  Node | -       |
 | button   | Button component (required)            |  Node | -       |
 | style    | Menu style                             | Style | -       |
+| onHidden | Callback when menu has become hidden   | Func  | -       |
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ class App extends React.PureComponent {
 
 ### Properties
 
-| name     | description                            |  type | default |
-| :------- | :------------------------------------- | ----: | :------ |
-| children | Components rendered in menu (required) |  Node | -       |
-| button   | Button component (required)            |  Node | -       |
-| style    | Menu style                             | Style | -       |
-| onHidden | Callback when menu has become hidden   | Func  | -       |
+| name     | description                            |     type | default |
+| :------- | :------------------------------------- | -------: | :------ |
+| children | Components rendered in menu (required) |     Node | -       |
+| button   | Button component (required)            |     Node | -       |
+| style    | Menu style                             |    Style | -       |
+| onHidden | Callback when menu has become hidden   | Function | -       |
 
 ### Methods
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -29,6 +29,7 @@ class Menu extends React.Component {
     button: PropTypes.node.isRequired,
     children: PropTypes.node.isRequired,
     style: ViewPropTypes.style,
+    onHidden: PropTypes.func,
   };
 
   state = {
@@ -102,14 +103,18 @@ class Menu extends React.Component {
       toValue: 0,
       duration: ANIMATION_DURATION,
       easing: EASING,
-    }).start(() =>
+    }).start(() => {
       // Reset state
       this.setState({
         menuState: STATES.HIDDEN,
         menuSizeAnimation: new Animated.ValueXY({ x: 0, y: 0 }),
         opacityAnimation: new Animated.Value(0),
-      }),
-    );
+      });
+      // Invoke onHidden callback if defined
+      if (this.props.onHidden) {
+        this.props.onHidden();
+      }
+    });
   };
 
   render() {


### PR DESCRIPTION
If a `MenuItem` has an `onPress` that opens a custom modal. For instance it sets the state of a component to `true` which in turn makes a `Modal` visible then it will fail because 'hide()' is still animating and making the `Modal` in `Menu` to not visible.

This fix enables to define a `onHidden` function that is invoked when the animation has completed. Allowing the user to open a `Modal` without doing a `setTimeout()`.