### PR TITLE
Adding Spread to MenuItem

### DIFF
--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -11,7 +11,6 @@ function MenuItem({
   style,
   textStyle,
   underlayColor,
-  testID,
   ...props
 }) {
   return (
@@ -21,7 +20,6 @@ function MenuItem({
       onPress={onPress}
       style={[styles.container, style]}
       underlayColor={underlayColor}
-      testID={testID}
     >
       <Text
         ellipsizeMode={Platform.OS === 'ios' ? 'clip' : 'tail'}
@@ -44,7 +42,6 @@ MenuItem.propTypes = {
   disabledTextColor: PropTypes.string,
   onPress: PropTypes.func,
   style: TouchableHighlight.propTypes.style,
-  testID: Text.propTypes.testID,
   textStyle: Text.propTypes.style,
   underlayColor: TouchableHighlight.propTypes.underlayColor,
 };

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -12,9 +12,11 @@ function MenuItem({
   textStyle,
   underlayColor,
   testID,
+  ...props
 }) {
   return (
     <TouchableHighlight
+      {...props}
       disabled={disabled}
       onPress={onPress}
       style={[styles.container, style]}


### PR DESCRIPTION
This change adds a spread to MenuItem so additional props can be passed through (onShowOverlay, onHideOverlay, onPressIn, onPressOut, etc).

Previously you could change the overlay color for MenuItems, but there was no good way to update the text color at the same time. The only event callback was onPress but that doesn't fire until AFTER the user has lifted his or her touch.