### PR TITLE
fix crash on react-native-web

### DIFF
--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -26,7 +26,7 @@ function MenuItem({
   ...props
 }) {
   const touchableProps = Platform.select({
-    android: { background: TouchableNativeFeedback.SelectableBackground() },
+    android: { background: Platform.OS === "android"? TouchableNativeFeedback.SelectableBackground() : {} },
     default: {},
   });
 

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -25,10 +25,10 @@ function MenuItem({
   textStyle,
   ...props
 }) {
-  const touchableProps = Platform.select({
-    android: { background: Platform.OS === "android"? TouchableNativeFeedback.SelectableBackground() : {} },
-    default: {},
-  });
+  const touchableProps =
+    Platform.OS === 'android'
+      ? { background: TouchableNativeFeedback.SelectableBackground() }
+      : {};
 
   return (
     <Touchable


### PR DESCRIPTION
Since there is no implementation of TouchableNativeFeedback for react-native-web, it crashes when trying to call SelectableBackground method. this pull request make sure that only on android it'll be called.