### PR TITLE
Accept button prop of type ElementType

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ export default App;
 
 ### Properties
 
-| name     | description                            |           type | default |
-| :------- | :------------------------------------- | -------------: | :------ |
-| children | Components rendered in menu (required) |           Node | -       |
-| button   | Button component (required)            | Node/Component | -       |
-| style    | Menu style                             |          Style | -       |
-| onHidden | Callback when menu has become hidden   |       Function | -       |
+| name     | description                            |             type | default |
+| :------- | :------------------------------------- | ---------------: | :------ |
+| children | Components rendered in menu (required) |             Node | -       |
+| button   | Button component (required)            | Node/ElementType | -       |
+| style    | Menu style                             |            Style | -       |
+| onHidden | Callback when menu has become hidden   |         Function | -       |
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ export default App;
 
 ### Properties
 
-| name     | description                            |     type | default |
-| :------- | :------------------------------------- | -------: | :------ |
-| children | Components rendered in menu (required) |     Node | -       |
-| button   | Button component (required)            |     Node | -       |
-| style    | Menu style                             |    Style | -       |
-| onHidden | Callback when menu has become hidden   | Function | -       |
+| name     | description                            |           type | default |
+| :------- | :------------------------------------- | -------------: | :------ |
+| children | Components rendered in menu (required) |           Node | -       |
+| button   | Button component (required)            | Node/Component | -       |
+| style    | Menu style                             |          Style | -       |
+| onHidden | Callback when menu has become hidden   |       Function | -       |
 
 ### Methods
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-material-menu",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Material Menu for React Native",
   "main": "src/index.js",
   "keywords": [

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -190,7 +190,8 @@ class Menu extends React.Component {
 
     return (
       <View ref={this._setContainerRef} collapsable={false} testID={testID}>
-        <View> { <ButtonComponent /> || button }</View>
+
+        <View>{(!!ButtonComponent) ? <ButtonComponent /> : button}</View>
 
         <Modal
           visible={modalVisible}
@@ -230,7 +231,10 @@ class Menu extends React.Component {
 }
 
 Menu.propTypes = {
-  button: PropTypes.oneOf([PropTypes.node, PropTypes.func]).isRequired,
+  button: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.elementType,
+  ]).isRequired,
   children: PropTypes.node.isRequired,
   onHidden: PropTypes.func,
   style: ViewPropTypes.style,

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -186,9 +186,11 @@ class Menu extends React.Component {
 
     const { testID, button, style, children } = this.props;
 
+    const ButtonComponent = (typeof button === 'function') ? button : null;
+
     return (
       <View ref={this._setContainerRef} collapsable={false} testID={testID}>
-        <View>{button}</View>
+        <View> { <ButtonComponent /> || button }</View>
 
         <Modal
           visible={modalVisible}
@@ -228,7 +230,7 @@ class Menu extends React.Component {
 }
 
 Menu.propTypes = {
-  button: PropTypes.node.isRequired,
+  button: PropTypes.oneOf([PropTypes.node, PropTypes.func]).isRequired,
   children: PropTypes.node.isRequired,
   onHidden: PropTypes.func,
   style: ViewPropTypes.style,


### PR DESCRIPTION
Hey @mxck, me again! 🎉 

To workaround the upstream issue with React Native Web, it's important to be able to specify a `button` prop using a component declaration as opposed to a `node`. These changes include:

  - Update `propTypes` to support `oneOfType[PropTypes.node, PropTypes.elementType]`.
  - Use a condition to determine whether to embed the `button` as normal, or attempt to instantiate a component (as `<ButtonComponent />`).
  - Updated `README.md`.
  - Bump to `0.6.7`

(Sorry for peppering you with PRs, by the way!)