### PR TITLE
Enable the onHidden callback even for iOS

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -120,7 +120,7 @@ class Menu extends React.Component {
           }
 
           // Invoke onHidden callback if defined
-          if (Platform.OS !== 'ios' && this.props.onHidden) {
+          if (this.props.onHidden) {
             this.props.onHidden();
           }
         },


### PR DESCRIPTION
I couldn't find exactly why this was disabled, but I enabled it back. It works fine on RN 0.63.