### PR TITLE
fixing modal not hiding because of the animation

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -124,6 +124,12 @@ class Menu extends React.Component {
 
   // @@ TODO: Rework this
   _hide = () => {
+    if (!!this.props.blockedHide) {
+      // Avoid Menu to be closed on every screen clicked.
+
+      return;
+    }
+
     this.hide();
   };
 


### PR DESCRIPTION
On the `hide()` method, when the `menuState` is being setted as `HIDDEN`, this was triggering the `_onMenuLayout()` method, so the `menuState` was immediately being setted to `ANIMATING`, which was causing the `modalVisible` variable to be `true`. So, though this was an unwanted behavior, in mobile it wasn't showing, but in web, because of the modal wasn't closing, it stayed and forced you to click on the screen again so that it closed after the menu disappeared.

I simply added that when the `menuState` is `HIDDEN`, the `_onMenuLayout()` method ignores that trigger.