### PR TITLE
feat: Add offset and custom RTL props

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,16 @@ export default App;
 
 ### Properties
 
-| name              | description                            |     type | default |
-| :---------------- | :------------------------------------- | -------: | :------ |
-| children          | Components rendered in menu (required) |     Node | -       |
-| button            | Button component (required)            |     Node | -       |
-| style             | Menu style                             |    Style | -       |
-| onHidden          | Callback when menu has become hidden   | Function | -       |
-| animationDuration | Changes show() and hide() duration     |   Number | 300     |
+| name              | description                            |     type | default           |
+| :---------------- | :------------------------------------- | -------: | :---------------- |
+| children          | Components rendered in menu (required) |     Node | -                 |
+| button            | Button component (required)            |     Node | -                 |
+| style             | Menu style                             |    Style | -                 |
+| onHidden          | Callback when menu has become hidden   | Function | -                 |
+| animationDuration | Changes show() and hide() duration     |   Number | 300               |
+| offsetX           | Menu position horizontal offset        |   Number | 0                 |
+| offsetY           | Menu position vertical offset          |   Number | 0                 |
+| isRTL             | Defines if menu is RTL                 |  Boolean | I18nManager.isRTL |
 
 ### Methods
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -128,7 +128,15 @@ class Menu extends React.Component {
   };
 
   render() {
-    const { isRTL } = I18nManager;
+    const {
+      testID,
+      button,
+      style,
+      children,
+      offsetX,
+      offsetY,
+      isRTL,
+    } = this.props;
 
     const dimensions = Dimensions.get('window');
     const { width: windowWidth } = dimensions;
@@ -179,17 +187,15 @@ class Menu extends React.Component {
     const shadowMenuContainerStyle = {
       opacity: opacityAnimation,
       transform: transforms,
-      top,
+      top: top + offsetY,
 
       // Switch left to right for rtl devices
-      ...(isRTL ? { right: left } : { left }),
+      ...(isRTL ? { right: left + offsetX } : { left: left + offsetX }),
     };
 
     const { menuState } = this.state;
     const animationStarted = menuState === STATES.ANIMATING;
     const modalVisible = menuState === STATES.SHOWN || animationStarted;
-
-    const { testID, button, style, children } = this.props;
 
     return (
       <View ref={this._setContainerRef} collapsable={false} testID={testID}>
@@ -233,6 +239,9 @@ class Menu extends React.Component {
 
 Menu.defaultProps = {
   animationDuration: 300,
+  offsetX: 0,
+  offsetY: 0,
+  isRTL: I18nManager.isRTL,
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Currently, the menu covers the label and I need to achieve something like in the picture. Passing custom horizontal and vertical offset allows me to achieve this. Also, custom `isRTL` prop to render it like RTL.

<img width="224" alt="Screen Shot 2021-05-05 at 12 07 32 PM" src="https://user-images.githubusercontent.com/36528176/117096026-843b9c00-ad9a-11eb-8d46-c02b68cfe2ed.png">
