### PR TITLE
Fix modal disappearance issue

### DIFF
--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -231,7 +231,7 @@ export class Menu extends React.Component<MenuProps, State> {
         {anchor}
 
         <Modal
-          visible={modalVisible}
+          visible={modalVisible && this.props.visible}
           onRequestClose={this.onRequestClose}
           supportedOrientations={[
             'portrait',


### PR DESCRIPTION
The modal remains visible even when the prop `visible` is false. This is an issue with the variable `modalVisible`. A quick fix is to show the modal only when `modalVisible` is true and prop `visible` is also true. 